### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -33,6 +33,12 @@ class ItemsController < ApplicationController
       redirect_to item_path
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,8 +37,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.destroy
-      redirect_to root_path
+    if @item.user == current_user
+      if @item.destroy
+        redirect_to root_path
+      end
     end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path, method: :delete, class:"item-destroy" %>
       <% else %>
         <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   get 'items/index'
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
## What
商品削除機能の実装
## Why
商品削除機能の実装のため

- items_controllerにdestroyアクションを定義し、ルーティングも設定した（７つ全てのアクションが揃ったため、onlyオプションを削除した）
- show.html.erbの削除ボタンにdestroyアクションのルーティングを設定した

### 実装確認用Gyazo
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/6adb11fc23f9d1ba081eb2b26c44722a