### PR TITLE
エラーメッセージの日本語対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,4 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'payjp'
 gem 'aws-sdk-s3', require: false
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (7.0.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.4.4)
       actionpack (= 6.0.4.4)
       activesupport (= 6.0.4.4)
@@ -333,6 +336,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,7 +10,8 @@ class Item < ApplicationRecord
   belongs_to :prefecture
   belongs_to :shipping_date
   
-  validates :category_id, :item_status_id, :shipping_fee_id, :prefecture_id, :shipping_date_id, numericality: { other_than: 1 }
+  validates :category_id, :item_status_id, :shipping_fee_id, :prefecture_id, :shipping_date_id, numericality: { other_than: 1, message: "を選択してください" }
+
   validates :image, :item_name, :introduction, presence: true
   validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }
 

--- a/app/models/purchase_destination.rb
+++ b/app/models/purchase_destination.rb
@@ -11,7 +11,7 @@ class PurchaseDestination
     validates :phone_number, format: {with: /\A\d{10,11}\z/}
     validates :token
   end
-  validates :prefecture_id, numericality: {other_than: 1, message: "can't be blank"}
+  validates :prefecture_id, numericality: {other_than: 1, message: "を選択してください"}
 
   def save
     # 購入情報(purchase)を保存する記述

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Furima37292
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,20 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        user_family_name: 苗字
+        user_first_name: 名前
+        user_family_name_kana: 苗字の読み仮名
+        user_first_name_kana: 名前の読み仮名
+        birthday: 誕生日
+      item:
+        category_id: カテゴリー
+        item_status_id: 商品の状態
+        shipping_fee_id: 配送料の負担
+        prefecture_id: 発送元の地域
+        shipping_date_id: 発送までの日数
+        image: 商品画像
+        item_name: 商品名
+        introduction: 商品の説明
+        price: 販売価格

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,3 +18,12 @@ ja:
         item_name: 商品名
         introduction: 商品の説明
         price: 販売価格
+  activemodel:
+    attributes:
+      purchase_destination:
+        post_code: 郵便番号
+        city: 市町村名
+        block: 番地
+        phone_number: 電話番号
+        token: クレジットカード情報
+        prefecture_id: 都道府県

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -17,67 +17,67 @@ RSpec.describe Item, type: :model do
       it '画像が空では出品できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include("商品画像を入力してください")
       end
       it 'item_nameが空だと出品できない' do
         @item.item_name = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item name can't be blank")
+        expect(@item.errors.full_messages).to include("商品名を入力してください")
       end
       it 'introductionが空だと出品できない' do
         @item.introduction = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Introduction can't be blank")
+        expect(@item.errors.full_messages).to include("商品の説明を入力してください")
       end
       it 'category_idが1だと出品できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include("カテゴリーを選択してください")
       end
       it 'item_status_idが1だと出品できない' do
         @item.item_status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item status must be other than 1")
+        expect(@item.errors.full_messages).to include("商品の状態を選択してください")
       end
       it 'shipping_fee_idが1だと出品できない' do
         @item.shipping_fee_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee must be other than 1")
+        expect(@item.errors.full_messages).to include("配送料の負担を選択してください")
       end
       it 'prefecture_idが1だと出品できない' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture must be other than 1")
+        expect(@item.errors.full_messages).to include("発送元の地域を選択してください")
       end
       it 'shipping_date_idが1だと出品できない' do
         @item.shipping_date_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping date must be other than 1")
+        expect(@item.errors.full_messages).to include("発送までの日数を選択してください")
       end
       it 'priceが空だと出品できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank")
+        expect(@item.errors.full_messages).to include("販売価格を入力してください")
       end
       it 'priceが全角数字だと出品できない' do
         @item.price = '９９９９９９９'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include("販売価格は数値で入力してください")
       end
       it 'priceが300以下だと出品できない' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+        expect(@item.errors.full_messages).to include("販売価格は300以上の値にしてください")
       end
       it 'priceが9999999以上だと出品できない' do
         @item.price = 10000000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
+        expect(@item.errors.full_messages).to include("販売価格は9999999以下の値にしてください")
       end
       it 'userが紐付いていないと出品できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include("Userを入力してください")
       end
     end
 

--- a/spec/models/purchase_destination_spec.rb
+++ b/spec/models/purchase_destination_spec.rb
@@ -26,62 +26,62 @@ RSpec.describe PurchaseDestination, type: :model do
       it 'post_codeが空だと保存できない' do
         @purchase_destination.post_code = ''
         @purchase_destination.valid?
-        expect(@purchase_destination.errors.full_messages).to include("Post code can't be blank")
+        expect(@purchase_destination.errors.full_messages).to include("郵便番号を入力してください")
       end
       it 'post_codeが数字だけでは保存できない' do
         @purchase_destination.post_code = '1234567'
         @purchase_destination.valid?
-        expect(@purchase_destination.errors.full_messages).to include("Post code is invalid")
+        expect(@purchase_destination.errors.full_messages).to include("郵便番号は不正な値です")
       end
       it 'prefecture_idが1だと保存できない' do
         @purchase_destination.prefecture_id = 1
         @purchase_destination.valid?
-        expect(@purchase_destination.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@purchase_destination.errors.full_messages).to include("都道府県を選択してください")
       end
       it 'cityが空だと保存できない' do
         @purchase_destination.city = ''
         @purchase_destination.valid?
-        expect(@purchase_destination.errors.full_messages).to include("City can't be blank")
+        expect(@purchase_destination.errors.full_messages).to include("市町村名を入力してください")
       end
       it 'blockが空だと保存できない' do
         @purchase_destination.block = ''
         @purchase_destination.valid?
-        expect(@purchase_destination.errors.full_messages).to include("Block can't be blank")
+        expect(@purchase_destination.errors.full_messages).to include("番地を入力してください")
       end
       it 'phone_numberが空だと保存できない' do
         @purchase_destination.phone_number = ''
         @purchase_destination.valid?
-        expect(@purchase_destination.errors.full_messages).to include("Phone number can't be blank")
+        expect(@purchase_destination.errors.full_messages).to include("電話番号を入力してください")
       end
       it 'phone_numberが10桁以下では保存できない' do
         @purchase_destination.phone_number = '123456789'
         @purchase_destination.valid?
-        expect(@purchase_destination.errors.full_messages).to include("Phone number is invalid")
+        expect(@purchase_destination.errors.full_messages).to include("電話番号は不正な値です")
       end
       it 'phone_numberが12桁以上では保存できない' do
         @purchase_destination.phone_number = '123456789012'
         @purchase_destination.valid?
-        expect(@purchase_destination.errors.full_messages).to include("Phone number is invalid")
+        expect(@purchase_destination.errors.full_messages).to include("電話番号は不正な値です")
       end
       it 'phone_numberが全角では保存できない' do
         @purchase_destination.phone_number = '１２３４５６７８９１０'
         @purchase_destination.valid?
-        expect(@purchase_destination.errors.full_messages).to include("Phone number is invalid")
+        expect(@purchase_destination.errors.full_messages).to include("電話番号は不正な値です")
       end
       it 'userが紐づいていないと保存できない' do
         @purchase_destination.user_id = nil
         @purchase_destination.valid?
-        expect(@purchase_destination.errors.full_messages).to include("User can't be blank")
+        expect(@purchase_destination.errors.full_messages).to include("Userを入力してください")
       end
       it 'itemが紐づいていないと保存できない' do
         @purchase_destination.item_id = nil
         @purchase_destination.valid?
-        expect(@purchase_destination.errors.full_messages).to include("Item can't be blank")
+        expect(@purchase_destination.errors.full_messages).to include("Itemを入力してください")
       end
       it 'tokenが空では保存できない' do
         @purchase_destination.token = nil
         @purchase_destination.valid?
-        expect(@purchase_destination.errors.full_messages).to include("Token can't be blank")
+        expect(@purchase_destination.errors.full_messages).to include("クレジットカード情報を入力してください")
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,103 +16,103 @@ RSpec.describe User, type: :model do
       it 'ニックネームが空の場合登録できない' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
       end
       it 'emailが空の場合登録できない' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("Eメールを入力してください")
       end
       it 'emailが重複していると登録できない' do
         @user.save
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include("Email has already been taken")
+        expect(another_user.errors.full_messages).to include("Eメールはすでに存在します")
       end
       it 'emailに@が含まれていないと登録できない' do
         @user.email = 'furima.com'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email is invalid")
+        expect(@user.errors.full_messages).to include("Eメールは不正な値です")
       end
       it 'パスワードが空の場合登録できない' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
       end
       it 'パスワードが5文字以下の場合登録できない' do
         @user.password = '00000'
         @user.password_confirmation = '00000'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)")
+        expect(@user.errors.full_messages).to include("パスワードは6文字以上で入力してください")
       end
       it 'passwordとpassword_confirmationが不一致では登録できない' do
         @user.password_confirmation = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
       it 'パスワードが全角英数字混合6文字以上の場合登録できない' do
         @user.password = "１２３ａｂｃ"
         @user.password_confirmation = "１２３ａｂｃ"
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is invalid")
+        expect(@user.errors.full_messages).to include("パスワードは不正な値です")
       end
       it 'パスワードが半角アルファベットのみの場合登録できない' do
         @user.password = "abcdef"
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is invalid")
+        expect(@user.errors.full_messages).to include("パスワードは不正な値です")
       end
       it 'パスワードが半角数字のみの場合登録できない' do
         @user.password = "123456"
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password is invalid")
+        expect(@user.errors.full_messages).to include("パスワードは不正な値です")
       end
       it 'お名前（全角）の名字が空の場合登録できない' do
         @user.user_family_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("User family name can't be blank")
+        expect(@user.errors.full_messages).to include("苗字を入力してください")
       end
       it 'お名前（全角）の名字が半角の場合登録できない' do
         @user.user_family_name = 'yamada'
         @user.valid?
-        expect(@user.errors.full_messages).to include("User family name is invalid")
+        expect(@user.errors.full_messages).to include("苗字は不正な値です")
       end
       it 'お名前（全角）の名前が空の場合登録できない' do
         @user.user_first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("User first name can't be blank")
+        expect(@user.errors.full_messages).to include("名前を入力してください")
       end
       it 'お名前（全角）の名前が半角の場合登録できない' do
         @user.user_first_name = 'taro'
         @user.valid?
-        expect(@user.errors.full_messages).to include("User first name is invalid")
+        expect(@user.errors.full_messages).to include("名前は不正な値です")
       end
       it 'お名前カナ（全角）の名字が空の場合登録できない' do
         @user.user_family_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("User family name kana can't be blank")
+        expect(@user.errors.full_messages).to include("苗字の読み仮名を入力してください")
       end
       it 'お名前カナ（全角）の名字がカタカナ以外の場合登録できない' do
         @user.user_family_name_kana = '山田'
         @user.valid?
-        expect(@user.errors.full_messages).to include("User family name kana is invalid")
+        expect(@user.errors.full_messages).to include("苗字の読み仮名は不正な値です")
       end
       it 'お名前カナ（全角）の名前が空の場合登録できない' do
         @user.user_first_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("User first name kana can't be blank")
+        expect(@user.errors.full_messages).to include("名前の読み仮名を入力してください")
       end
       it 'お名前カナ（全角）の名前がカタカナ以外の場合登録できない' do
         @user.user_first_name_kana = '花子'
         @user.valid?
-        expect(@user.errors.full_messages).to include("User first name kana is invalid")
+        expect(@user.errors.full_messages).to include("名前の読み仮名は不正な値です")
       end
       it '生年月日が空の場合登録できない' do
         @user.birthday = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Birthday can't be blank")
+        expect(@user.errors.full_messages).to include("誕生日を入力してください")
       end
     end
   end


### PR DESCRIPTION
### What
エラーメッセージの日本語対応
### Why
エラーメッセージが英語だとユーザーによっては分かりにくい場合があると考えたため。
新規登録、ログイン、商品出品、商品編集、購入画面にて表示されるエラーメッセージを日本語で表示されるようにした。